### PR TITLE
feat: enable to expose the app service with ingress resource

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -38,3 +38,21 @@ spec:
         env:
         - name: HELLO_MSG
           value: #@ data.values.hello_msg
+#@ if/end data.values.expose_svc == "true":
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: #@ data.values.namespace
+  name: #@ data.values.app_name
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: #@ data.values.app_name
+            port:
+              number: #@ data.values.svc_port

--- a/schema.yml
+++ b/schema.yml
@@ -21,3 +21,6 @@ namespace: default
 
 #@overlay/match missing_ok=True
 hello_msg: world
+
+#@overlay/match missing_ok=True
+expose_svc: "false"

--- a/values.yml
+++ b/values.yml
@@ -6,3 +6,4 @@ app_port: 80
 app_version: 0.0.1
 namespace: default
 hello_msg: stranger
+expose_svc: "false"


### PR DESCRIPTION
This is a primal version which requires obviously an Ingress controller.
By default set to `false`.